### PR TITLE
Install to user folder

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -20,6 +20,7 @@ __version__ = ".".join(map(str, bl_info["version"]))
 import sys
 import subprocess
 import bpy
+from pathlib import Path
 
 
 if bpy.app.version < (2, 91, 0):
@@ -97,7 +98,7 @@ class PMM_OT_PIPInstall(bpy.types.Operator):
             "install",
             *bpy.context.scene.pip_module_name.split(" "),
             "--target",
-            str(bpy.utils.script_path_user()),
+            Path(bpy.utils.script_path_user()) / "addons/modules",
         )
         return {"FINISHED"}
 


### PR DESCRIPTION
to avoid poluting system python site-packages, or blender install-dir site-packages, we can install to the blender user script path.
e.g. on windows this is `APPDATA/ roaming /blender/ v.3.3 /scripts/ addons /modules`