### PR TITLE
Pass env pythonpaths to pip

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -18,6 +18,7 @@ import sys
 import subprocess
 import bpy
 from pathlib import Path
+import os
 
 MODULES_FOLDER = Path(bpy.utils.user_resource("SCRIPTS")) / "modules"
 
@@ -36,6 +37,14 @@ def run_pip_command(self, *cmds, cols=False, run_module="pip"):
     global TEXT_OUTPUT
 
     cmds = [c for c in cmds if c is not None]
+
+    # combine all entries in os.path with path separator
+    joined_paths = os.pathsep.join(sys.path)
+    env_var = os.environ.get("PYTHONPATH")
+    if env_var:
+        os.environ["PYTHONPATH"] = f"{env_var}{os.pathsep}{joined_paths}"
+    else:
+        os.environ["PYTHONPATH"] = joined_paths
 
     # TODO: make this function only run pip commands, make separate function to run other modules
     # Choose where to save Python modules

--- a/__init__.py
+++ b/__init__.py
@@ -14,24 +14,9 @@ bl_info = {
 
 __version__ = ".".join(map(str, bl_info["version"]))
 
-# add user site to sys.path
-# binaries go to {site.USER_BASE}/bin
-# venv notice:
-#   https://stackoverflow.com/questions/33412974/
-#   how-to-uninstall-a-package-installed-with-pip-install-user/56948334#56948334
-import site
 import sys
 import subprocess
-
-app_path = site.getusersitepackages()
-print("Blender PIP user site:", app_path)
-if app_path not in sys.path:
-    print("Adding site to path")
-    sys.path.append(app_path)
-
 import bpy
-import numpy as np
-import mathutils as mu
 from pathlib import Path
 
 MODULES_FOLDER = Path(bpy.utils.user_resource("SCRIPTS")) / "modules"


### PR DESCRIPTION
this PR adds the ability to see local installed packages.
e.g. modules in the user addons folder

this relies on Blender taking care of the sys.path setup, avoiding any bugs with trying to recreate this logic ourselves.
we then add every path to PYTHONPATH, which is passed to the subprocess. giving pip access to the custom paths from the Blender session.
also removed some unused imports, and some site code that AFAIK is not used anywhere.

mirror PR on original repo https://github.com/amb/blender_pip/pull/11